### PR TITLE
Created a docker container, using alpine for portability

### DIFF
--- a/dns/docker/build.sh
+++ b/dns/docker/build.sh
@@ -1,0 +1,1 @@
+docker build --rm=true --force-rm=true -t muncus/internet-volume container

--- a/dns/docker/container/Dockerfile
+++ b/dns/docker/container/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+WORKDIR /root
+EXPOSE 53 5300
+
+RUN apk --update add ruby ruby-dev ruby-bundler ca-certificates build-base wget
+RUN wget -q https://raw.githubusercontent.com/muncus/internet-volume/master/dns/volume.rb ;\
+wget -q https://raw.githubusercontent.com/muncus/internet-volume/master/dns/Gemfile ; \
+bundler install
+
+ENTRYPOINT ["ruby", "/root/volume.rb"]

--- a/dns/docker/run.sh
+++ b/dns/docker/run.sh
@@ -1,0 +1,5 @@
+docker run -it -d --name internet-volume \
+-p 53:53 \
+-p 53:53/udp \
+-p 5300:5300/udp \
+muncus/internet-volume


### PR DESCRIPTION
Created docker container for internet volume.

Added a "docker" folder, which contains 3 parts:
* Dockerfile in a dedicated clean "container" folder for minimum memory while creating container
* build.sh for being able to build "as is"
* run.sh for being able to run as a daemon/so that there is an example of how to run it